### PR TITLE
remove ranger class check from BALDUR.BCS

### DIFF
--- a/IATweaks/lib/components/bulian/all_protagonists_ranger_quests.tph
+++ b/IATweaks/lib/components/bulian/all_protagonists_ranger_quests.tph
@@ -42,6 +42,12 @@ COPY_EXISTING ~AR0404.BCS~ ~override\AR0404.BCS~
     REPLACE_TEXTUALLY ~Class(Player1,RANGER_ALL)~ ~~
   END
 
+// Grandfather of Assassins note in the sewers beneath Copper Coronet
+COPY_EXISTING ~BALDUR.BCS~ ~override\BALDUR.BCS~
+  DECOMPILE_AND_PATCH BEGIN
+    REPLACE_TEXTUALLY ~Class(Player1,RANGER_ALL)~ ~~
+  END
+
 // Good, Bad n' Ugly, ranger cabin
 COPY_EXISTING ~AR1107.BCS~ ~override\AR1107.BCS~
   DECOMPILE_AND_PATCH BEGIN


### PR DESCRIPTION
what's up with this nomenclature?

[ %TAB%%LNL%%MNL%%WNL%]